### PR TITLE
Change submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dependencies/pharo-vm"]
 	path = dependencies/pharo-vm
-	url = git@github.com:pharo-project/pharo-vm.git
+	url = https://github.com/pharo-project/pharo-vm.git


### PR DESCRIPTION
The submodule ssh url could be problematic if the user doesn't use ssh authentication. The https url should work in all cases. This being a read-only submodule it shouldn't be a problem.
