### PR TITLE
Improve Pharo VM integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,6 @@ add_library(${PROJECT_NAME} SHARED src/generated/64/plugins/src/StarterPlugin/St
 #Add the VM dependency
 add_subdirectory(dependencies/pharo-vm)
 target_link_libraries(${PROJECT_NAME} PharoVMCore)
-target_include_directories(${PROJECT_NAME}
-    PRIVATE
-    ${PharoVM_BINARY_DIR}/build/include/pharovm/
-    ${PharoVM_BINARY_DIR}/build/include/pharovm/
-    ${PharoVM_SOURCE_DIR}/include/pharovm/
-    ${PharoVM_SOURCE_DIR}/extracted/vm/include/common
-    ${PharoVM_SOURCE_DIR}/extracted/vm/include/osx)
-
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_BINARY_DIR})
   
   # Try next:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,13 @@ add_library(${PROJECT_NAME} SHARED src/generated/64/plugins/src/StarterPlugin/St
 #Add the VM dependency
 add_subdirectory(dependencies/pharo-vm)
 target_link_libraries(${PROJECT_NAME} PharoVMCore)
-include_directories(${PharoVM_BINARY_DIR}/build/include/pharovm/)
-include_directories(${PharoVM_BINARY_DIR}/build/include/pharovm/)
-include_directories(${PharoVM_SOURCE_DIR}/include/pharovm/)
-include_directories(${PharoVM_SOURCE_DIR}/extracted/vm/include/common)
-include_directories(${PharoVM_SOURCE_DIR}/extracted/vm/include/osx)
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+    ${PharoVM_BINARY_DIR}/build/include/pharovm/
+    ${PharoVM_BINARY_DIR}/build/include/pharovm/
+    ${PharoVM_SOURCE_DIR}/include/pharovm/
+    ${PharoVM_SOURCE_DIR}/extracted/vm/include/common
+    ${PharoVM_SOURCE_DIR}/extracted/vm/include/osx)
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_BINARY_DIR})
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,23 +17,18 @@ ELSE()
 ENDIF()
 
 # The source of the library we want to build
-add_library(${PROJECT_NAME} src/generated/64/plugins/src/StarterPlugin/StarterPlugin.c)
+add_library(${PROJECT_NAME} SHARED src/generated/64/plugins/src/StarterPlugin/StarterPlugin.c)
 
+#Add the VM dependency
 add_subdirectory(dependencies/pharo-vm)
+target_link_libraries(${PROJECT_NAME} PharoVMCore)
+include_directories(${PharoVM_BINARY_DIR}/build/include/pharovm/)
+include_directories(${PharoVM_BINARY_DIR}/build/include/pharovm/)
+include_directories(${PharoVM_SOURCE_DIR}/include/pharovm/)
+include_directories(${PharoVM_SOURCE_DIR}/extracted/vm/include/common)
+include_directories(${PharoVM_SOURCE_DIR}/extracted/vm/include/osx)
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_BINARY_DIR})
-
-target_include_directories(${PROJECT_NAME}
-  PUBLIC src/generated/64/plugins/src/StarterPlugin
-  PRIVATE dependencies/builds/pharo-vm/
-  PRIVATE dependencies/builds/pharo-vm/build/include/pharovm/
-  PRIVATE dependencies/builds/pharo-vm/generated/64/vm/include
-  PRIVATE dependencies/pharo-vm/extracted/vm/include/osx
-  PRIVATE dependencies/pharo-vm/extracted/vm/include/common
-  PRIVATE dependencies/pharo-vm/include/pharovm/
-  PRIVATE dependencies/pharo-vm/extracted/vm/include/
-  PRIVATE dependencies/pharo-vm/include/
-  )
   
   # Try next:
   # PRIVATE dependencies/shinythirdparty/target/debug


### PR DESCRIPTION
- VM is built automatically
- the built plugin is set as a dynamic library

With these changes, I was able to build the plugin by just doing:

```bash
cmake -B build -S PharoPluginBuilder
cmake --build build --target StarterPlugin

cd ide
ln -s ../build/libStarterPlugin.dylib libStarterPlugin.dylib
#Then launch Pharo
```